### PR TITLE
zmiany w shared pointers 

### DIFF
--- a/Tutorial/ResourceFont.cpp
+++ b/Tutorial/ResourceFont.cpp
@@ -13,7 +13,7 @@ bool ResourceFont::LoadResource(const std::string& dir, uint heigh)
 {
 	if (initialized)
 	{
-		if (font.use_count() >= 0)
+		if (font.use_count() >0)
 		{
 			DEBUG_LOG("Trying to reinitialized font in use.");
 			return false;

--- a/Tutorial/ResourceFont.cpp
+++ b/Tutorial/ResourceFont.cpp
@@ -2,14 +2,14 @@
 
 
 
-ResourceFont::ResourceFont(std::string dir, uint h)
+ResourceFont::ResourceFont(const std::string& dir, uint h)
 	:height(h)
 {
 	LoadResource(dir, h);
 }
 
 
-bool ResourceFont::LoadResource(std::string dir, uint heigh)
+bool ResourceFont::LoadResource(const std::string& dir, uint heigh)
 {
 	if (initialized)
 	{
@@ -50,7 +50,7 @@ bool ResourceFont::good()
 
 bool ResourceFont::Destroy()
 {
-	if (initialized && font.use_count() == 0)
+	if (initialized && font.unique())
 	{
 		TTF_CloseFont(font.get());
 		font.reset();
@@ -58,7 +58,7 @@ bool ResourceFont::Destroy()
 	}
 	else
 	{
-		DEBUG_LOG("Trying to destroy texture with more than zero references");
+		DEBUG_LOG("Trying to destroy texture with more than one references");
 		return false;
 	}
 }

--- a/Tutorial/ResourceFont.h
+++ b/Tutorial/ResourceFont.h
@@ -8,13 +8,13 @@ class ResourceFont :
 {
 public:
 
-	ResourceFont(std::string dir, uint heigh);
+	ResourceFont(const std::string& dir, uint heigh);
 
 	ResourceFont(ResourceFont&);
 
 	ResourceFont& operator=(ResourceFont&);
 
-	bool LoadResource(std::string dir, uint heigh);
+	bool LoadResource(const std::string& dir, uint heigh);
 
 	~ResourceFont();
 	

--- a/Tutorial/ResourceFontTexture.cpp
+++ b/Tutorial/ResourceFontTexture.cpp
@@ -2,13 +2,13 @@
 
 
 
-ResourceFontTexture::ResourceFontTexture(std::string t, ResourceFont font, SDL_Renderer * renderer, Color color)
+ResourceFontTexture::ResourceFontTexture(const std::string& t, ResourceFont font, SDL_Renderer * renderer, Color color)
 	:text(t)
 {
 	LoadResource(t, font, renderer, color);
 }
 
-bool ResourceFontTexture::LoadResource(std::string text, ResourceFont font, SDL_Renderer * renderer, Color color)
+bool ResourceFontTexture::LoadResource(const std::string& text, ResourceFont font, SDL_Renderer * renderer, Color color)
 {
 	if (initialized)
 	{

--- a/Tutorial/ResourceFontTexture.h
+++ b/Tutorial/ResourceFontTexture.h
@@ -7,13 +7,13 @@ class ResourceFontTexture :
 {
 public:
 
-	ResourceFontTexture(std::string text, ResourceFont font, SDL_Renderer * renderer, Color color);
+	ResourceFontTexture(const std::string& text, ResourceFont font, SDL_Renderer * renderer, Color color);
 	
 	ResourceFontTexture(const ResourceFontTexture&);
 
 	ResourceFontTexture& operator=(const ResourceFontTexture&);
 
-	bool LoadResource(std::string text, ResourceFont font, SDL_Renderer * renderer, Color color);
+	bool LoadResource(const std::string& text, ResourceFont font, SDL_Renderer * renderer, Color color);
 	
 	~ResourceFontTexture();
 

--- a/Tutorial/ResourceTexture.cpp
+++ b/Tutorial/ResourceTexture.cpp
@@ -60,7 +60,7 @@ bool ResourceTexture::LoadResource(std::string dir, SDL_Renderer * renderer)
 
 bool ResourceTexture::Destroy()
 {
-	if (initialized && texture.use_count() == 0)
+	if (initialized && texture.unique())
 	{
 		SDL_DestroyTexture(texture.get());
 		texture.reset();
@@ -68,7 +68,7 @@ bool ResourceTexture::Destroy()
 	}
 	else
 	{
-		DEBUG_LOG("Trying to destroy texture with more than zero references");
+		DEBUG_LOG("Trying to destroy texture with more than one references");
 		return false;
 	}
 }

--- a/Tutorial/ResourceTexture.cpp
+++ b/Tutorial/ResourceTexture.cpp
@@ -20,7 +20,7 @@ ResourceTexture& ResourceTexture::operator=(const ResourceTexture& other)
 	return *this;
 }
 
-ResourceTexture::ResourceTexture(std::string dir, SDL_Renderer * renderer)
+ResourceTexture::ResourceTexture(const std::string& dir, SDL_Renderer * renderer)
 	: Resource(),texture(nullptr)
 {
 	LoadResource(dir, renderer);
@@ -31,7 +31,7 @@ bool ResourceTexture::good()
 	return initialized && texture != nullptr;
 }
 
-bool ResourceTexture::LoadResource(std::string dir, SDL_Renderer * renderer)
+bool ResourceTexture::LoadResource(const std::string& dir, SDL_Renderer * renderer)
 {
 	if (initialized)
 	{

--- a/Tutorial/ResourceTexture.h
+++ b/Tutorial/ResourceTexture.h
@@ -15,9 +15,9 @@ public:
 
 	ResourceTexture& operator=(const ResourceTexture&);
 
-	ResourceTexture(std::string dir, SDL_Renderer * renderer);
+	ResourceTexture(const std::string& dir, SDL_Renderer * renderer);
 
-	bool LoadResource(std::string dir, SDL_Renderer * renderer);
+	bool LoadResource(const std::string& dir, SDL_Renderer * renderer);
 
 	bool Destroy();
 


### PR DESCRIPTION
shared_pointer.use_count==0 oznacza że wskaźnik jest pusty, dlatego zaminiłem to na .unique()
dodałem rownież consty i referencje w funkcjach przyjmujacych stringi
